### PR TITLE
Fix unix server unlinking client's socket file

### DIFF
--- a/src/client/UnixDgramClientSockEP.cpp
+++ b/src/client/UnixDgramClientSockEP.cpp
@@ -38,7 +38,7 @@ UnixDgramClientSockEP::UnixDgramClientSockEP(std::string bindPath, std::string s
 }
 
 // for server side client creation
-UnixDgramClientSockEP::UnixDgramClientSockEP()
+UnixDgramClientSockEP::UnixDgramClientSockEP() : ownsSocketFile_{false}
 {
 	simpleLogger.debug << "Constructing Unix Dgram Client\n";
 }
@@ -46,7 +46,10 @@ UnixDgramClientSockEP::UnixDgramClientSockEP()
 UnixDgramClientSockEP::~UnixDgramClientSockEP()
 {
 	simpleLogger.debug << "Destructing Unix Dgram Client\n";
-	unlink(saddr_.sun_path);
+	if (ownsSocketFile_)
+	{
+		unlink(saddr_.sun_path);
+	}
 }
 
 /******* BOTH INTERFACES **********/

--- a/src/client/UnixDgramClientSockEP.h
+++ b/src/client/UnixDgramClientSockEP.h
@@ -36,6 +36,7 @@ public:
 
 private:
 	void handleIncomingMessage() override;
+	bool ownsSocketFile_{true};
 	struct sockaddr_un saddr_;
 	struct sockaddr_un serverSaddr_;
 };

--- a/src/client/UnixStreamClientSockEP.cpp
+++ b/src/client/UnixStreamClientSockEP.cpp
@@ -45,11 +45,14 @@ UnixStreamClientSockEP::UnixStreamClientSockEP(std::string bindPath, std::string
 }
 
 // for server side client creation
-UnixStreamClientSockEP::UnixStreamClientSockEP() {}
+UnixStreamClientSockEP::UnixStreamClientSockEP() : ownsSocketFile_{false} {}
 
 UnixStreamClientSockEP::~UnixStreamClientSockEP()
 {
-	unlink(saddr_.sun_path);
+	if (ownsSocketFile_)
+	{
+		unlink(saddr_.sun_path);
+	}
 }
 
 

--- a/src/client/UnixStreamClientSockEP.h
+++ b/src/client/UnixStreamClientSockEP.h
@@ -36,6 +36,7 @@ public:
 
 private:
 	void handleIncomingMessage() override;
+	bool ownsSocketFile_{true};
 	struct sockaddr_un saddr_;
 	struct sockaddr_un serverSaddr_;
 };


### PR DESCRIPTION
When a unix socket server (both stream and datagram) destructs a client, it unlinks that client's socket file. This causes dgram sendto calls to fail with errno 2 (ENOENT). Since the server does not own the client's socket file, it should not unlink it.

This change adds a variable to track if the class owns the socket file and only unlinks it when it does.