### PR TITLE
Fix recv thread not joining after hup

### DIFF
--- a/src/client/ClientSockEP.cpp
+++ b/src/client/ClientSockEP.cpp
@@ -113,12 +113,10 @@ void ClientSockEP::runThread()
 int ClientSockEP::stopRecvThread()
 {
 	simpleLogger.debug << "Stopping recv thread\n";
-	if (!threadRunning_)
+	if (threadRunning_)
 	{
-		simpleLogger.debug << "Thread not running\n";
-		return 0;
+		close(pipeFd_[1]);
 	}
-	close(pipeFd_[1]);
 	if (recvThread_.joinable())
 	{
 		simpleLogger.debug << "Joining...\n";


### PR DESCRIPTION
When a HUP is received, threadRunning_ is set to false. When the ClientSockEP destructor is called, stopRecvThread skips joining the thread. Then, when the std::thread is destructed, an exception and thrown and the program terminates unexpectedly because the thread has not been joined yet.