### PR TITLE
Mitigate static initialization order issues with SimpleLogger

### DIFF
--- a/lib/simpleLogger/include/simpleLogger/SimpleLogger.h
+++ b/lib/simpleLogger/include/simpleLogger/SimpleLogger.h
@@ -44,7 +44,8 @@ public:
 	};
 
 	// Singleton accessor
-	static SimpleLogger &get();
+	static std::shared_ptr<SimpleLogger> instancePtr();
+	inline static SimpleLogger &instance() { return *instancePtr(); }
 
 	template <typename T>
 	SimpleLogger &operator<<(const T &x)
@@ -73,9 +74,11 @@ private:
 	{
 	}
 
-
 	std::ostream *stream_{nullptr};
 	Level level_{Level::warning};
 };
 
-#define simpleLogger SimpleLogger::get()
+// create a local copy of the shared_ptr in each Compilation Unit (.cpp file)
+static std::shared_ptr<SimpleLogger> localLogger = SimpleLogger::instancePtr();
+
+#define simpleLogger SimpleLogger::instance()

--- a/lib/simpleLogger/src/SimpleLogger.cpp
+++ b/lib/simpleLogger/src/SimpleLogger.cpp
@@ -8,13 +8,9 @@
 #define SIMPLE_LOGGER_OSTREAM std::cout
 #endif
 
-SimpleLogger &SimpleLogger::get()
+std::shared_ptr<SimpleLogger> SimpleLogger::instancePtr()
 {
-	static std::unique_ptr<SimpleLogger> s_simpleLogger;
-	if (!s_simpleLogger)
-	{
-		s_simpleLogger =
-		    std::unique_ptr<SimpleLogger>(new SimpleLogger(&SIMPLE_LOGGER_OSTREAM, Level::SIMPLE_LOGGER_LEVEL));
-	}
-	return *s_simpleLogger;
+	static std::shared_ptr<SimpleLogger> instance =
+	    std::shared_ptr<SimpleLogger>(new SimpleLogger(&SIMPLE_LOGGER_OSTREAM, Level::SIMPLE_LOGGER_LEVEL));
+	return instance;
 }

--- a/lib/simpleLogger/src/SimpleLogger.cpp
+++ b/lib/simpleLogger/src/SimpleLogger.cpp
@@ -8,11 +8,9 @@
 #define SIMPLE_LOGGER_OSTREAM std::cout
 #endif
 
-static std::unique_ptr<SimpleLogger> s_simpleLogger;
-
-
 SimpleLogger &SimpleLogger::get()
 {
+	static std::unique_ptr<SimpleLogger> s_simpleLogger;
 	if (!s_simpleLogger)
 	{
 		s_simpleLogger =


### PR DESCRIPTION
Moving the SimpleLogger static singleton instance inside its `get()` function to alter its lifetime slightly such that consumers of the logger do not cause a use-after-free problem.